### PR TITLE
Add npm publish pipeline for @shopify/shopify-ai-toolkit

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -1,0 +1,27 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+
+      - name: Set version from release tag
+        run: npm version --no-git-tag-version "${GITHUB_REF_NAME#v}"
+
+      - name: Publish
+        run: npm publish --access public --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -2,26 +2,35 @@ name: Publish to npm
 
 on:
   release:
-    types: [published]
+    types: [created]
+
+permissions:
+  contents: read
+  id-token: write
 
 jobs:
   publish:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
+    runs-on: shopify-ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@a0853c24544627f65ddf259abe73b1d18a591444 # v5.0.0
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Set version from release tag
-        run: npm version --no-git-tag-version "${GITHUB_REF_NAME#v}"
+      - name: Verify version matches release tag
+        run: |
+          PACKAGE_VERSION=$(node -p "require('./package.json').version")
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+
+          echo "Package version: $PACKAGE_VERSION"
+          echo "Tag version:     $TAG_VERSION"
+
+          if [ "$PACKAGE_VERSION" != "$TAG_VERSION" ]; then
+            echo "Version mismatch: package.json ($PACKAGE_VERSION) != tag ($TAG_VERSION)"
+            exit 1
+          fi
 
       - name: Publish
         run: npm publish --access public --provenance
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -1,9 +1,17 @@
 {
-  "name": "shopify-plugin",
+  "name": "@shopify/shopify-ai-toolkit",
   "version": "1.0.0",
-  "private": true,
-  "description": "AI agent plugin manifests for the Shopify Dev MCP server",
+  "description": "AI agent skills for building Shopify apps — GraphQL, Liquid, Hydrogen, UI Extensions, and more",
   "author": "Shopify",
   "license": "MIT",
-  "keywords": ["shopify", "mcp", "graphql", "liquid", "storefront", "admin-api", "plugin"]
+  "keywords": ["shopify", "agent-skills", "graphql", "liquid", "storefront", "admin-api", "hydrogen", "polaris"],
+  "files": [
+    "skills/",
+    "README.md"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Shopify/shopify-ai-toolkit.git"
+  },
+  "homepage": "https://github.com/Shopify/shopify-ai-toolkit#readme"
 }


### PR DESCRIPTION
## Summary

- Rename package to `@shopify/shopify-ai-toolkit`, remove `private`, add `files: ["skills/", "README.md"]`
- Add `.github/workflows/publish-npm.yml`: triggers on release created, verifies `package.json` version matches the release tag, publishes via `shopify-ubuntu-latest` (internal runner handles npm auth)

## How to publish

1. Bump `version` in `package.json` and merge to main
2. Create a GitHub release tagged `v<version>` — the workflow fires automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)