### PR TITLE
Add optional step to admin skill to use admin-execution skill

### DIFF
--- a/skills/shopify-admin/SKILL.md
+++ b/skills/shopify-admin/SKILL.md
@@ -18,6 +18,7 @@ You have a `bash` tool. Every response must use it — in this order:
    (Always include these flags. Use your actual model name for YOUR_MODEL_ID; use claude-code/cursor/etc. for YOUR_CLIENT_NAME)
 4. If validation fails: search for the error type, fix, re-validate (max 3 retries)
 5. Return code only after validation passes
+6. **Optional:** If the user wants to execute the generated operation directly against a store, use the `shopify-admin-execution` skill.
 
 **You must run both search_docs.js and validate.js in every response. Do not return code to the user without completing step 3.**
 


### PR DESCRIPTION
## Summary
- When a user wants to execute a generated GQL operation directly against a store, the agent now has an explicit optional step (step 6) directing it to use the `shopify-admin-execution` skill
- Previously, agents starting with the `shopify-admin` skill would not reach for `shopify-admin-execution` after generating the operation, falling back to model knowledge (asking for API keys, pointing to GQL explorer, etc.)

## Context
Raised in [#devtools-proj-agent-plugins](https://shopify.slack.com/archives/C0AN8J5Q482/p1775558519313619). This is a bandaid fix to ship before re-indexing while a longer-term solution is being explored.

## Test plan
- [ ] Load `shopify-admin` skill and prompt for a GQL operation with intent to execute against a store
- [ ] Verify agent reaches for `shopify-admin-execution` skill instead of asking for API keys or redirecting to GQL explorer

🤖 Generated with [Claude Code](https://claude.com/claude-code)