### PR TITLE
Fix marketplace.json source format for Claude Code install

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,10 @@
   "plugins": [
     {
       "name": "shopify-plugin",
-      "source": "./",
+      "source": {
+        "source": "github",
+        "repo": "Shopify/Shopify-AI-Toolkit"
+      },
       "description": "Search Shopify docs, generate and validate GraphQL, Liquid, and UI extension code",
       "version": "1.0.0",
       "author": { "name": "Shopify" },


### PR DESCRIPTION
## Summary

Fixes #10. `/plugin install shopify-plugin@shopify-ai-toolkit` currently fails with `Invalid input` on `plugins[0].source` because `marketplace.json` sets `source` to the bare string `"./"`, which is not a valid shape per the Claude Code plugin marketplace schema.

Per the [official plugin-marketplaces docs](https://code.claude.com/docs/en/plugin-marketplaces#plugin-sources), a plugin `source` must be either:
- a relative path string that points to a plugin subdirectory (e.g. `"./plugins/my-plugin"`), or
- an object with one of `github`, `url`, `git-subdir`, or `npm`.

Since `plugin.json` and `.claude-plugin/` already live at the repo root here, the simplest fix that avoids any layout change is the `github` source form. That's also the variant used by most entries in the official `anthropics/claude-plugins-official` marketplace.

## Change

`.claude-plugin/marketplace.json`:

```diff
-      "source": "./",
+      "source": {
+        "source": "github",
+        "repo": "Shopify/Shopify-AI-Toolkit"
+      },
```

No plugin contents moved. No other files touched.

Note: I deliberately did not adopt the `{"source": "local", "path": "./"}` shape suggested in the issue body — `"local"` is not one of the source types in the current schema, so that would still fail validation. The `github` form is documented and covers this case.

## Verification

- `claude plugin validate .` → `✔ Validation passed` on this branch (fails on `main`).
- After this lands, the install flow from the issue (`/plugin marketplace add Shopify/Shopify-AI-Toolkit` then `/plugin install shopify-plugin@shopify-ai-toolkit`) should complete without schema errors, since the marketplace catalog now points Claude Code at the same repo to fetch the plugin contents.

## Test plan
- [ ] `claude plugin validate .` passes
- [ ] `/plugin marketplace add Shopify/Shopify-AI-Toolkit` succeeds
- [ ] `/plugin install shopify-plugin@shopify-ai-toolkit` succeeds on Claude Code v2.x
- [ ] Installed plugin exposes the 16 skills under `skills/`