### PR TITLE
Surface telemetry disclosure in README and plugin.json

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "shopify-plugin",
-  "description": "Shopify developer tools for Claude Code — search Shopify docs, generate and validate GraphQL, Liquid, and UI extension code",
+  "description": "Shopify developer tools for Claude Code — search Shopify docs, generate and validate GraphQL, Liquid, and UI extension code. Skill scripts send usage telemetry (queries, code, model/client identifiers) to shopify.dev by default; set OPT_OUT_INSTRUMENTATION=true to disable.",
   "version": "1.2.1",
   "author": { "name": "Shopify" },
   "license": "MIT",

--- a/README.md
+++ b/README.md
@@ -37,6 +37,22 @@ The Toolkit gives your agent access to Shopify's documentation, API schemas, and
 - **Store management**: Manage your Shopify store through the CLI's store execute capabilities
 - **Auto-updates**: The plugin updates automatically as new capabilities are released
 
+## Telemetry
+
+The skill scripts (`scripts/search_docs.mjs`, `scripts/validate.mjs`) send a usage event to `https://shopify.dev/mcp/usage` on each invocation. The payload includes:
+
+- tool name, skill name and version
+- model name, client name, and client version (when supplied as flags)
+- the search query text (for `search_docs.mjs`)
+- the code, filename, file type, theme path, and file list being validated (for `validate.mjs`), along with the validation result
+- artifact ID and revision number (when supplied)
+
+This is **on by default**. To opt out, set the environment variable:
+
+```
+OPT_OUT_INSTRUMENTATION=true
+```
+
 ## Other install methods
 
 If your platform doesn't support plugins, you can install agent skills or the Dev MCP server directly. For instructions, see [shopify.dev/docs/apps/build/ai-toolkit](https://shopify.dev/docs/apps/build/ai-toolkit).

--- a/skills/shopify-admin/SKILL.md
+++ b/skills/shopify-admin/SKILL.md
@@ -81,4 +81,4 @@ scripts/validate.mjs --code '...' --model YOUR_MODEL_NAME --client-name YOUR_CLI
 
 ---
 
-> **Privacy notice:** `scripts/validate.mjs` reports anonymized validation results (pass/fail and skill name) to Shopify to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.
+> **Privacy notice:** `scripts/validate.mjs` reports the validated code, filename, file type, validation result, skill name/version, and model/client identifiers to Shopify (`shopify.dev/mcp/usage`) to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.

--- a/skills/shopify-customer/SKILL.md
+++ b/skills/shopify-customer/SKILL.md
@@ -80,4 +80,4 @@ scripts/validate.mjs --code '...' --model YOUR_MODEL_NAME --client-name YOUR_CLI
 
 ---
 
-> **Privacy notice:** `scripts/validate.mjs` reports anonymized validation results (pass/fail and skill name) to Shopify to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.
+> **Privacy notice:** `scripts/validate.mjs` reports the validated code, filename, file type, validation result, skill name/version, and model/client identifiers to Shopify (`shopify.dev/mcp/usage`) to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.

--- a/skills/shopify-dev/SKILL.md
+++ b/skills/shopify-dev/SKILL.md
@@ -27,3 +27,7 @@ Search for the **topic or feature name**, not the full user prompt.
 > If the user is asking about the Admin API, Liquid themes, Checkout Extensions,
 > or any other named Shopify API, use the corresponding skill instead
 > (e.g. shopify-admin-graphql, shopify-liquid, shopify-checkout-extensions, …).
+
+---
+
+> **Privacy notice:** `scripts/search_docs.mjs` reports the search query, skill name/version, and model/client identifiers to Shopify (`shopify.dev/mcp/usage`) to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.

--- a/skills/shopify-functions/SKILL.md
+++ b/skills/shopify-functions/SKILL.md
@@ -379,4 +379,4 @@ scripts/validate.mjs --code '...' --model YOUR_MODEL_NAME --client-name YOUR_CLI
 
 ---
 
-> **Privacy notice:** `scripts/validate.mjs` reports anonymized validation results (pass/fail and skill name) to Shopify to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.
+> **Privacy notice:** `scripts/validate.mjs` reports the validated code, filename, file type, validation result, skill name/version, and model/client identifiers to Shopify (`shopify.dev/mcp/usage`) to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.

--- a/skills/shopify-hydrogen/SKILL.md
+++ b/skills/shopify-hydrogen/SKILL.md
@@ -3450,4 +3450,4 @@ scripts/validate.mjs --code '...' --model YOUR_MODEL_NAME --client-name YOUR_CLI
 
 ---
 
-> **Privacy notice:** `scripts/validate.mjs` reports anonymized validation results (pass/fail and skill name) to Shopify to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.
+> **Privacy notice:** `scripts/validate.mjs` reports the validated code, filename, file type, validation result, skill name/version, and model/client identifiers to Shopify (`shopify.dev/mcp/usage`) to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.

--- a/skills/shopify-liquid/SKILL.md
+++ b/skills/shopify-liquid/SKILL.md
@@ -324,4 +324,4 @@ Call once per codeblock. `--filetype` defaults to `sections` when omitted.
 
 ---
 
-> **Privacy notice:** `scripts/validate.mjs` reports anonymized validation results (pass/fail and skill name) to Shopify to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.
+> **Privacy notice:** `scripts/validate.mjs` reports the validated code, filename, file type, validation result, skill name/version, and model/client identifiers to Shopify (`shopify.dev/mcp/usage`) to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.

--- a/skills/shopify-partner/SKILL.md
+++ b/skills/shopify-partner/SKILL.md
@@ -78,4 +78,4 @@ scripts/validate.mjs --code '...' --model YOUR_MODEL_NAME --client-name YOUR_CLI
 
 ---
 
-> **Privacy notice:** `scripts/validate.mjs` reports anonymized validation results (pass/fail and skill name) to Shopify to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.
+> **Privacy notice:** `scripts/validate.mjs` reports the validated code, filename, file type, validation result, skill name/version, and model/client identifiers to Shopify (`shopify.dev/mcp/usage`) to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.

--- a/skills/shopify-payments-apps/SKILL.md
+++ b/skills/shopify-payments-apps/SKILL.md
@@ -81,4 +81,4 @@ scripts/validate.mjs --code '...' --model YOUR_MODEL_NAME --client-name YOUR_CLI
 
 ---
 
-> **Privacy notice:** `scripts/validate.mjs` reports anonymized validation results (pass/fail and skill name) to Shopify to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.
+> **Privacy notice:** `scripts/validate.mjs` reports the validated code, filename, file type, validation result, skill name/version, and model/client identifiers to Shopify (`shopify.dev/mcp/usage`) to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.

--- a/skills/shopify-polaris-admin-extensions/SKILL.md
+++ b/skills/shopify-polaris-admin-extensions/SKILL.md
@@ -214,4 +214,4 @@ scripts/validate.mjs --code '...' --model YOUR_MODEL_NAME --client-name YOUR_CLI
 
 ---
 
-> **Privacy notice:** `scripts/validate.mjs` reports anonymized validation results (pass/fail and skill name) to Shopify to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.
+> **Privacy notice:** `scripts/validate.mjs` reports the validated code, filename, file type, validation result, skill name/version, and model/client identifiers to Shopify (`shopify.dev/mcp/usage`) to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.

--- a/skills/shopify-polaris-app-home/SKILL.md
+++ b/skills/shopify-polaris-app-home/SKILL.md
@@ -300,4 +300,4 @@ scripts/validate.mjs --code '...' --model YOUR_MODEL_NAME --client-name YOUR_CLI
 
 ---
 
-> **Privacy notice:** `scripts/validate.mjs` reports anonymized validation results (pass/fail and skill name) to Shopify to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.
+> **Privacy notice:** `scripts/validate.mjs` reports the validated code, filename, file type, validation result, skill name/version, and model/client identifiers to Shopify (`shopify.dev/mcp/usage`) to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.

--- a/skills/shopify-polaris-checkout-extensions/SKILL.md
+++ b/skills/shopify-polaris-checkout-extensions/SKILL.md
@@ -290,4 +290,4 @@ scripts/validate.mjs --code '...' --model YOUR_MODEL_NAME --client-name YOUR_CLI
 
 ---
 
-> **Privacy notice:** `scripts/validate.mjs` reports anonymized validation results (pass/fail and skill name) to Shopify to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.
+> **Privacy notice:** `scripts/validate.mjs` reports the validated code, filename, file type, validation result, skill name/version, and model/client identifiers to Shopify (`shopify.dev/mcp/usage`) to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.

--- a/skills/shopify-polaris-customer-account-extensions/SKILL.md
+++ b/skills/shopify-polaris-customer-account-extensions/SKILL.md
@@ -375,4 +375,4 @@ scripts/validate.mjs --code '...' --model YOUR_MODEL_NAME --client-name YOUR_CLI
 
 ---
 
-> **Privacy notice:** `scripts/validate.mjs` reports anonymized validation results (pass/fail and skill name) to Shopify to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.
+> **Privacy notice:** `scripts/validate.mjs` reports the validated code, filename, file type, validation result, skill name/version, and model/client identifiers to Shopify (`shopify.dev/mcp/usage`) to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.

--- a/skills/shopify-pos-ui/SKILL.md
+++ b/skills/shopify-pos-ui/SKILL.md
@@ -317,4 +317,4 @@ scripts/validate.mjs --code '...' --model YOUR_MODEL_NAME --client-name YOUR_CLI
 
 ---
 
-> **Privacy notice:** `scripts/validate.mjs` reports anonymized validation results (pass/fail and skill name) to Shopify to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.
+> **Privacy notice:** `scripts/validate.mjs` reports the validated code, filename, file type, validation result, skill name/version, and model/client identifiers to Shopify (`shopify.dev/mcp/usage`) to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.

--- a/skills/shopify-storefront-graphql/SKILL.md
+++ b/skills/shopify-storefront-graphql/SKILL.md
@@ -73,4 +73,4 @@ scripts/validate.mjs --code '...' --model YOUR_MODEL_NAME --client-name YOUR_CLI
 
 ---
 
-> **Privacy notice:** `scripts/validate.mjs` reports anonymized validation results (pass/fail and skill name) to Shopify to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.
+> **Privacy notice:** `scripts/validate.mjs` reports the validated code, filename, file type, validation result, skill name/version, and model/client identifiers to Shopify (`shopify.dev/mcp/usage`) to help improve these tools. Set `OPT_OUT_INSTRUMENTATION=true` in your environment to opt out.


### PR DESCRIPTION
The skill scripts post a usage event to `shopify.dev/mcp/usage` on every invocation:

- `search_docs.mjs` sends the search query text
- `validate.mjs` sends the validated code, filename, file type, theme path, file list, and validation result
- both send model and client name/version in headers

The `OPT_OUT_INSTRUMENTATION=true` opt-out exists, but it's currently documented only in per-skill `SKILL.md` files. Users installing the plugin see the README and the `plugin.json` description — neither mentions telemetry today.

This PR:

- Adds a **Telemetry** section to `README.md` describing the endpoint, payload, default-on behavior, and opt-out
- Adds a one-sentence telemetry mention with the opt-out env var to the `plugin.json` `description` (shown at install time)
- Adds the missing privacy notice to `skills/shopify-dev/SKILL.md` (its `search_docs.mjs` pings the endpoint but the SKILL.md had no notice)
- Corrects the payload description in 13 `SKILL.md` privacy notices — they currently say "anonymized validation results (pass/fail and skill name)," which understates what `validate.mjs` actually sends; updated to list the actual fields

No behavior change — this is documentation only.