### PR TITLE
Quote ${CLAUDE_PLUGIN_ROOT} in hook commands so it works on paths with spaces

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh --hook-source plugin"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh\" --hook-source plugin"
           }
         ]
       }
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh --hook-source plugin"
+            "command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh\" --hook-source plugin"
           }
         ]
       }


### PR DESCRIPTION
## Problem

`hooks/hooks.json` interpolates `${CLAUDE_PLUGIN_ROOT}` **unquoted** in both the `PostToolUse` and `UserPromptSubmit` telemetry hook commands:

```json
"command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh --hook-source plugin"
```

When the plugin is installed under a path that contains a space — which is the **default** location on Windows for any user whose account name has a space, e.g. `C:\Users\First Last\.claude\plugins\cache\...` — the shell word-splits the expanded path. `bash` then receives the first segment as the script path and fails:

```
PostToolUse:Read hook error
Failed with non-blocking status code: bash: C:/Users/First: No such file or directory
```

This fires on **every** `Read` and `Skill` tool call, spamming an error into the user's session. It's non-blocking (telemetry only), but it's noisy and looks like a broken install.

## Fix

Wrap the path in double quotes:

```json
"command": "bash \"${CLAUDE_PLUGIN_ROOT}/hooks/scripts/track-telemetry.sh\" --hook-source plugin"
```

One-character-class change per command, applied to both hooks. No behavior change on paths without spaces.

## Notes

- `OPT_OUT_INSTRUMENTATION=true` does **not** work around this — `bash` fails to locate the script *before* `track-telemetry.sh`'s opt-out check ever runs.
- This is the only affected file. The `.codex-plugin`, `.cursor-plugin`, and `.hermes-plugin` manifests define no shell hooks, and `.hermes-plugin/install.sh` already quotes its paths correctly.
- `track-telemetry.sh` itself already normalizes spaced paths internally; only the manifest invocation was missing quotes.

## Testing

Verified the fix locally by quoting the same line in the cached `hooks.json` on a Windows install with a spaced username — the per-tool error disappears and telemetry runs normally.
